### PR TITLE
fix: [EXP-4] The request can't be submitted continuously

### DIFF
--- a/src/lib/components/ExpenseDrawerContent.svelte
+++ b/src/lib/components/ExpenseDrawerContent.svelte
@@ -146,7 +146,9 @@
 		return '';
 	}
 
-	async function handleSubmit() {
+	async function handleSubmit(e: Event) {
+		e.preventDefault(); // prevent page reload
+		
 		const err = validateForm();
 		if (err) {
 			alert(err);
@@ -182,9 +184,13 @@
 		};
 		Logger.log('Would submit payload:', payload);
 
-		const saved = await upsertExpense(payload);
-		// 更新到全域 expenses store
-		upsertOne(saved);
+		try {
+			const saved = await upsertExpense(payload);
+			// 更新到全域 expenses store
+			upsertOne(saved);
+		} catch (error) {
+			Logger.error('Upsert expense error:', error);
+		}
 		onSubmitFinish?.();
 	}
 


### PR DESCRIPTION
## Issue
On the Svelte static page, submitting a form that triggers a Supabase request (e.g., `upsert`) works correctly the first time,
but subsequent submissions fail — no new network request is sent, and the form only works again after a full page refresh.

## Root Cause
By default, HTML `<form>` elements automatically trigger a page **reload** (or **navigation**) on submission.
Since the original implementation didn’t prevent this default behavior:

- The page was being reloaded after the first submission.
- The Supabase client instance and all JS states were reset.
- Event listeners were detached, causing further submissions to stop working.

As a result, it looked like “the first request works, but the second one doesn’t.”

## Fix
Prevent the form’s default submission behavior by adding `preventDefault` to the Svelte `onsubmit` handler:
```JS
function handleSubmit(event) {
  event.preventDefault();
  ...
}
```

## Additional Notes
This issue can also occur in similar cases:
- Using `<button>` inside a form without specifying `type="button"` (default is `type="submit"`)
- Submitting forms in SPA frameworks (SvelteKit / React / Vue) without preventing default navigation
- When the framework’s router intercepts form submissions, causing component remounts or navigation

## Summary
This change ensures:
- The page no longer reloads after form submission
- The `onsubmit` handler can be triggered multiple times
- Supabase requests work consistently across repeated operations