### PR TITLE
Feat: improve the expanse card with carousel and add alert-dialog for the ai dialog

### DIFF
--- a/src/lib/components/AIReceiptImportDialog.svelte
+++ b/src/lib/components/AIReceiptImportDialog.svelte
@@ -7,9 +7,10 @@
 		ReceiptResult
 	} from '$lib/types/expense';
 	import * as Dialog from '$lib/components/shadcn/dialog';
-	// import { Button } from '$lib/components/shadcn/button';
+	import * as AlertDialog from '$lib/components/shadcn/alert-dialog';
+	import { Button } from '$lib/components/shadcn/button';
 	import { user } from '$lib/stores/session.store';
-	import { Sparkles, Upload, CircleCheckBig } from 'lucide-svelte';
+	import { Sparkles, Upload, CircleCheckBig, X } from 'lucide-svelte';
 
 	// Child components
 	import StepHeader from './ai-receipt/StepHeader.svelte';
@@ -33,6 +34,7 @@
 	let selectedFiles = $state<File[]>([]);
 	let previewUrls = $state<string[]>([]);
 	let lastUploadedFilePaths = $state<string[]>([]);
+	let showConfirmClose = $state(false);
 
 	let analysisResult = $state<ReceiptResult | null>(null);
 
@@ -101,7 +103,33 @@
 </script>
 
 <Dialog.Root bind:open>
-	<Dialog.Content class="sm:max-w-[425px] max-h-[90vh] overflow-hidden flex flex-col">
+	<Dialog.Content
+		class="sm:max-w-[425px] max-h-[90vh] overflow-hidden flex flex-col"
+		onInteractOutside={(e) => {
+			if (aiStep > 1) {
+				e.preventDefault();
+				showConfirmClose = true;
+			}
+		}}
+		onEscapeKeydown={(e) => {
+			if (aiStep > 1) {
+				e.preventDefault();
+				showConfirmClose = true;
+			}
+		}}
+		showCloseButton={aiStep === 1}
+	>
+		{#if aiStep > 1}
+			<Button
+				variant="ghost"
+				class="absolute right-2 top-2 h-8 w-8 p-0"
+				onclick={() => (showConfirmClose = true)}
+			>
+				<X class="h-4 w-4" />
+				<span class="sr-only">Close</span>
+			</Button>
+		{/if}
+
 		<StepHeader
 			{aiStep}
 			{wizardSteps}
@@ -151,3 +179,25 @@
 		</div>
 	</Dialog.Content>
 </Dialog.Root>
+
+<AlertDialog.Root bind:open={showConfirmClose}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>確認取消匯入？</AlertDialog.Title>
+			<AlertDialog.Description>
+				目前的進度將會遺失，且上傳的收據將不會被儲存。
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>繼續匯入</AlertDialog.Cancel>
+			<AlertDialog.Action
+				onclick={() => {
+					open = false;
+					showConfirmClose = false;
+				}}
+			>
+				確認取消
+			</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/ai-receipt/ConfirmStep.svelte
+++ b/src/lib/components/ai-receipt/ConfirmStep.svelte
@@ -276,45 +276,50 @@
 	}
 </script>
 
-<div class="mt-4 space-y-4">
-	<div class="flex items-center justify-between px-1">
-		<p class="text-sm text-muted-foreground">整理項目並送出：</p>
-		{#if !isSelectionMode}
-			<Button
-				variant="ghost"
-				size="sm"
-				class="h-8 gap-1 text-xs"
-				onclick={() => (isSelectionMode = true)}
-			>
-				<Group class="size-3" />
-				合併
-			</Button>
-		{:else}
-			<div class="flex gap-2">
+<div class="flex flex-col min-h-full">
+	<!-- Sticky Header -->
+	<div class="sticky top-0 z-20 -mx-1 bg-popover/95 px-1 py-1 backdrop-blur-sm">
+		<div class="flex items-center justify-between">
+			<p class="text-sm font-medium text-muted-foreground">整理項目並送出：</p>
+			{#if !isSelectionMode}
 				<Button
-					variant="outline"
+					variant="ghost"
 					size="sm"
 					class="h-8 gap-1 text-xs"
-					onclick={handleCancelSelection}
+					onclick={() => (isSelectionMode = true)}
 				>
-					<X class="size-3" />
-					取消
+					<Group class="size-3" />
+					合併
 				</Button>
-				<Button
-					variant="default"
-					size="sm"
-					class="h-8 gap-1 text-xs"
-					disabled={selectedIds.size < 2}
-					onclick={handleMergeSelected}
-				>
-					<Check class="size-3" />
-					合併所選 ({selectedIds.size})
-				</Button>
-			</div>
-		{/if}
+			{:else}
+				<div class="flex gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						class="h-8 gap-1 text-xs"
+						onclick={handleCancelSelection}
+					>
+						<X class="size-3" />
+						取消
+					</Button>
+					<Button
+						variant="default"
+						size="sm"
+						class="h-8 gap-1 text-xs"
+						disabled={selectedIds.size < 2}
+						onclick={handleMergeSelected}
+					>
+						<Check class="size-3" />
+						合併所選 ({selectedIds.size})
+					</Button>
+				</div>
+			{/if}
+		</div>
+		<div class="absolute bottom-0 left-0 right-0 h-px bg-border/50"></div>
 	</div>
 
-	<div class="space-y-4">
+	<!-- Scrollable Content Area -->
+	<div class="flex-1 space-y-4 py-4">
 		{#each groupedItems as group (group.id)}
 			<div class="flex gap-1">
 				{#if !isSelectionMode}

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/shadcn/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.ActionProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	data-slot="alert-dialog-action"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-action", className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/shadcn/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "outline",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.CancelProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	data-slot="alert-dialog-cancel"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-cancel", className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import AlertDialogPortal from "./alert-dialog-portal.svelte";
+	import AlertDialogOverlay from "./alert-dialog-overlay.svelte";
+	import { cn, type WithoutChild, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		size = "default",
+		portalProps,
+		...restProps
+	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
+		size?: "default" | "sm";
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof AlertDialogPortal>>;
+	} = $props();
+</script>
+
+<AlertDialogPortal {...portalProps}>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		data-size={size}
+		class={cn(
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			className
+		)}
+		{...restProps}
+	/>
+</AlertDialogPortal>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn("text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3", className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-footer"
+	class={cn(
+		"bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-header"
+	class={cn("grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-media.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-media.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-media"
+	class={cn("bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn("text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2", className)}
+	{...restProps}
+/>

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog-trigger.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref data-slot="alert-dialog-trigger" {...restProps} />

--- a/src/lib/components/shadcn/alert-dialog/alert-dialog.svelte
+++ b/src/lib/components/shadcn/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/shadcn/alert-dialog/index.ts
+++ b/src/lib/components/shadcn/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import Root from "./alert-dialog.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Trigger from "./alert-dialog-trigger.svelte";
+import Title from "./alert-dialog-title.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+import Media from "./alert-dialog-media.svelte";
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	Media,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+	Media as AlertDialogMedia,
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,8 @@
 	import { categoryIconMap } from '$lib/stores/categories.store';
 
 	import * as Dialog from '$lib/components/shadcn/dialog';
+	import * as Carousel from '$lib/components/shadcn/carousel';
+	import type { CarouselAPI } from '$lib/components/shadcn/carousel/context';
 	import { Button } from '$lib/components/shadcn/button';
 	import ExpenseDrawerContent from '$lib/components/ExpenseDrawerContent.svelte';
 	import ExpenseListSection from '$lib/components/ExpenseListSection.svelte';
@@ -17,7 +19,7 @@
 	import AIReceiptImportDialog from '$lib/components/AIReceiptImportDialog.svelte';
 
 	import Logger from '$lib/utils/logger';
-	import { Sparkles } from 'lucide-svelte';
+	import { Sparkles, TreePalm } from 'lucide-svelte';
 
 	let drawerOpen = $state(false);
 	let editMode = $state(false);
@@ -31,10 +33,6 @@
 	// 改為從 store 過濾當日資料
 	const expensesItems = expensesStore.items;
 	const expensesLoading = expensesStore.loading;
-	const dayItems = $derived.by(() => {
-		const { from, to } = taiwanDayBoundsISO(selectedDate);
-		return ($expensesItems ?? []).filter((e) => e.ts >= from && e.ts <= to);
-	});
 
 	// 依選擇日期，若該月份資料未在 store 中，則載入該月份
 	$effect(() => {
@@ -63,17 +61,6 @@
 	function isToday(dateStr: string) {
 		return dateStr === toDateOnlyStr(today);
 	}
-	function shiftDay(delta: number) {
-		if (delta > 0 && isToday(selectedDate)) {
-			return;
-		}
-		const [y, m, d] = selectedDate.split('-').map(Number);
-		const next = toDateOnlyStr(new Date(y, m - 1, d + delta));
-		if (delta > 0 && next > toDateOnlyStr(today)) {
-			return;
-		}
-		selectedDate = next;
-	}
 
 	function openCreate() {
 		editMode = false;
@@ -93,83 +80,136 @@
 		expensesStore.setMoreItems(expenses);
 	}
 
-	let startX = 0,
-		dx = 0;
-	const SWIPE = 60;
-	function onTouchStart(e: TouchEvent) {
-		startX = e.touches[0].clientX;
-		dx = 0;
-	}
-	function onTouchMove(e: TouchEvent) {
-		dx = e.touches[0].clientX - startX;
-	}
-	function onTouchEnd() {
-		if (dx < -SWIPE) {
-			shiftDay(+1);
+	// Carousel sync logic
+	let carouselApi = $state<CarouselAPI>();
+	let initialized = $state(false);
+
+	const dateList = $derived.by(() => {
+		const list = [];
+		const start = new Date(today);
+		start.setDate(start.getDate() - 60);
+		for (let i = 0; i <= 60; i++) {
+			const d = new Date(start);
+			d.setDate(d.getDate() + i);
+			list.push(toDateOnlyStr(d));
 		}
-		if (dx > SWIPE) {
-			shiftDay(-1);
+		return list;
+	});
+
+	$effect(() => {
+		if (carouselApi && selectedDate) {
+			const index = dateList.indexOf(selectedDate);
+			if (index !== -1 && index !== carouselApi.selectedScrollSnap()) {
+				carouselApi.scrollTo(index, !initialized);
+				initialized = true;
+			}
 		}
-		startX = 0;
-		dx = 0;
-	}
+	});
+
+	$effect(() => {
+		if (carouselApi) {
+			const onSelect = () => {
+				const index = carouselApi!.selectedScrollSnap();
+				const newDate = dateList[index];
+				if (newDate && newDate !== selectedDate) {
+					selectedDate = newDate;
+				}
+			};
+			carouselApi.on('select', onSelect);
+			return () => carouselApi!.off('select', onSelect);
+		}
+	});
 </script>
 
-<section
-	class="card p-4"
-	role="presentation"
-	ontouchstart={onTouchStart}
-	ontouchmove={onTouchMove}
-	ontouchend={onTouchEnd}
->
-	<div class="flex items-center justify-center relative">
-		<RetrieveExpenseButton className="absolute left-0 text-[var(--c-primary)]" {monthKey} />
-		<button class="px-2 py-1" onclick={() => shiftDay(-1)}>◀</button>
+<div class="py-2">
+	<div class="flex items-center justify-between px-4 py-3 mb-4 bg-card/50 backdrop-blur-sm rounded-2xl border border-border/50 shadow-sm">
+		<div class="flex items-center gap-4">
+			<div class="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors hover:bg-primary/20">
+				<RetrieveExpenseButton {monthKey} />
+			</div>
+			<div class="flex flex-col">
+				<span class="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/60">
+					{isToday(selectedDate) ? 'Today' : 'History'}
+				</span>
+				<div class="relative flex items-center">
+					<input
+						type="date"
+						value={selectedDate}
+						class="bg-transparent border-none p-0 text-base font-black tracking-tight focus:ring-0 cursor-pointer appearance-none"
+						max={toDateOnlyStr(today)}
+						oninput={(e) => {
+							const target = e.target as HTMLInputElement;
+							if (!target.value) {
+								selectedDate = toDateOnlyStr(today);
+								return;
+							}
+							selectedDate = target.value;
+						}}
+					/>
+				</div>
+			</div>
+		</div>
 
-		<input
-			type="date"
-			value={selectedDate}
-			class="px-3 py-1 rounded-md bg-[var(--c-bg)]"
-			max={toDateOnlyStr(today)}
-			oninput={(e) => {
-				const target = e.target as HTMLInputElement;
-				if (!target.value) {
-					selectedDate = toDateOnlyStr(today);
-					return;
-				}
-				selectedDate = target.value;
-			}}
-		/>
-		<button
-			class="px-2 py-1 disabled:opacity-40"
-			disabled={isToday(selectedDate)}
-			onclick={() => shiftDay(+1)}
-		>
-			▶
-		</button>
+		<div class="flex items-center gap-2">
+			{#if !isToday(selectedDate)}
+				<Button 
+					variant="secondary" 
+					size="sm" 
+					class="h-8 rounded-full px-4 text-[10px] font-black uppercase tracking-widest shadow-sm transition-all hover:scale-105 active:scale-95"
+					onclick={() => selectedDate = toDateOnlyStr(today)}
+				>
+					Today
+				</Button>
+			{/if}
+		</div>
 	</div>
 
-	{#if $expensesLoading && dayItems.length === 0}
-		<p class="mt-3 opacity-70">載入中…</p>
-	{:else}
-		{#if dayItems.length !== 0}
-			<ExpenseListSection
-				items={dayItems}
-				categoryIconMap={$categoryIconMap}
-				onEdit={openEdit}
-				showSum={true}
-			/>
-		{/if}
-		<div class="mt-3 flex gap-2">
-			<Button class="grow" onclick={openCreate}
-				>{dayItems.length === 0 ? '今日第一筆記帳' : '新增項目'}</Button
-			>
-			<Button class="text-primary" variant="outline" onclick={() => (aiDialogOpen = true)}>
-				<Sparkles class="w-5 h-5" />
-			</Button>
-		</div>
-	{/if}
-</section>
+	<Carousel.Root
+		setApi={(api) => (carouselApi = api)}
+		opts={{ align: 'center', containScroll: false }}
+		class="w-full"
+	>
+		<Carousel.Content class="items-start">
+			{#each dateList as date (date)}
+				{@const { from, to } = taiwanDayBoundsISO(date)}
+				{@const items = ($expensesItems ?? []).filter((e) => e.ts >= from && e.ts <= to)}
+				<Carousel.Item class="basis-[85%] pl-4">
+					<section class="card p-4">
+						{#if $expensesLoading && items.length === 0 && selectedDate === date}
+							<p class="mt-3 opacity-70 text-sm font-medium">載入中…</p>
+						{:else}
+							{#if items.length !== 0}
+								<ExpenseListSection
+									{items}
+									categoryIconMap={$categoryIconMap}
+									onEdit={openEdit}
+									showSum={true}
+								/>
+							{:else}
+								<div class="py-12 flex flex-col items-center justify-center opacity-30">
+									<TreePalm class="w-8 h-8 mb-2" />
+									<p class="text-xs font-bold uppercase tracking-widest">No Records</p>
+								</div>
+							{/if}
+							<div class="mt-4 flex gap-2">
+								<Button class="grow font-bold shadow-sm" onclick={openCreate}
+									>{items.length === 0 ? '今日第一筆記帳' : '新增項目'}</Button
+								>
+								<Button
+									class="text-primary hover:bg-primary/5 border-primary/20"
+									variant="outline"
+									onclick={() => (aiDialogOpen = true)}
+								>
+									<Sparkles class="w-5 h-5" />
+								</Button>
+							</div>
+						{/if}
+					</section>
+				</Carousel.Item>
+			{/each}
+		</Carousel.Content>
+	</Carousel.Root>
+</div>
 
 <Dialog.Root bind:open={drawerOpen}>
 	<Dialog.Content class="max-h-[75vh] overflow-y-auto sm:max-w-[425px]">
@@ -188,6 +228,3 @@
 </Dialog.Root>
 
 <AIReceiptImportDialog bind:open={aiDialogOpen} onImport={handleImport} />
-
-<style>
-</style>


### PR DESCRIPTION
## Summary
  This PR focuses on improving the user experience of the main expense list and enhancing the AI receipt
  import workflow. Key updates include a transition to carousel-based navigation for dates and the addition
  of safety mechanisms to prevent data loss during AI processing.

1. Carousel-based Date Navigation
   * New Navigation: Replaced the legacy manual date switcher on the home page with a swipeable Carousel.
     Users can now browse through a 60-day history by swiping left or right.
   * Sync Logic: Implemented two-way synchronization between the carousel and the date picker.
   * Quick Action: Added a "Today" button to quickly jump back to the current date from historical views.
   * Empty State: Introduced a visual "No Records" state with a dedicated icon for days without expenses.
2. AI Receipt Import Safety & UX
   * Accidental Closure Protection: Integrated a confirmation Alert Dialog that triggers if a user attempts
     to close the AI import dialog (via background click, ESC key, or close button) while in the middle of
     analysis or confirmation steps.
   * Sticky Controls: In the AI confirmation step, the "Merge" and "Selection" tools are now part of a
3. Component Updates
   * New Component: Installed and configured the alert-dialog component from the shadcn/ui library to
     support the new safety prompts