### PR TITLE
remove unused auth methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"heic2any": "^0.0.4",
 				"idb-keyval": "^6.2.2",
 				"is-mobile": "^5.0.0",
-				"jose": "^6.2.3",
 				"lodash": "^4.17.21",
 				"lucide-svelte": "^1.0.1",
 				"swipe-listener": "^1.3.0"
@@ -6095,15 +6094,6 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
-		"node_modules/jose": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 		"heic2any": "^0.0.4",
 		"idb-keyval": "^6.2.2",
 		"is-mobile": "^5.0.0",
-		"jose": "^6.2.3",
 		"lodash": "^4.17.21",
 		"lucide-svelte": "^1.0.1",
 		"swipe-listener": "^1.3.0"

--- a/src/lib/data/ai-receipt.fetcher.ts
+++ b/src/lib/data/ai-receipt.fetcher.ts
@@ -1,7 +1,6 @@
-import { PUBLIC_GOOGLE_AI_GCF, PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { PUBLIC_GOOGLE_AI_GCF } from '$env/static/public';
 import { supabase } from '$lib/supabase/supabaseClient';
 import Logger from '$lib/utils/logger';
-import * as jose from 'jose';
 
 async function getAccessToken() {
 	const {
@@ -16,16 +15,6 @@ async function getAccessToken() {
 
 export async function getUploadUrl(files: { file_name: string; content_type: string }[]) {
 	const accessToken = await getAccessToken();
-
-	try {
-		const JWKS = jose.createRemoteJWKSet(
-			new URL(`${PUBLIC_SUPABASE_URL}/auth/v1/.well-known/jwks.json`)
-		);
-		await jose.jwtVerify(accessToken, JWKS);
-	} catch (error) {
-		Logger.error('Token verification failed:', error);
-		throw error;
-	}
 
 	const response = await fetch(PUBLIC_GOOGLE_AI_GCF, {
 		method: 'POST',

--- a/src/lib/supabase/auth.ts
+++ b/src/lib/supabase/auth.ts
@@ -2,96 +2,10 @@ import { supabase } from '$lib/supabase/supabaseClient';
 import {
 	loading as sessionLoading,
 	reset as resetUser,
-	setFromLoad as setUser,
-	user as currentUser,
+	setFromLoad as setUser
 } from '$lib/stores/session.store';
 import { base } from '$app/paths';
 import { page } from '$app/state';
-
-const SIGN_IN_AT_KEY = 'expense-app:sign-in-at';
-const SIGN_IN_TTL_KEY = 'expense-app:sign-in-ttl';
-
-export const DEFAULT_AUTO_SIGN_OUT_MS = 1000 * 60 * 60 * 8; // eight hours
-
-interface StoredSignInInfo {
-	signedInAt: number;
-	ttlMs: number;
-}
-
-/**
- * Persists the current sign-in timestamp and optional TTL so we can later decide
- * whether the session is stale. No-op on the server.
- *
- * @param durationMs - Maximum age (milliseconds) before the session is considered expired.
- */
-export function persistSignInTimestamp(durationMs = DEFAULT_AUTO_SIGN_OUT_MS) {
-	if (typeof window === 'undefined') {
-		return;
-	}
-	const storage = window.localStorage;
-	const now = Date.now();
-	storage.setItem(SIGN_IN_AT_KEY, `${now}`);
-	storage.setItem(SIGN_IN_TTL_KEY, `${durationMs}`);
-}
-
-/**
- * Removes any stored sign-in metadata from localStorage. No-op on the server.
- */
-export function clearSignInTracking() {
-	if (typeof window === 'undefined') {
-		return;
-	}
-	const storage = window.localStorage;
-	storage.removeItem(SIGN_IN_AT_KEY);
-	storage.removeItem(SIGN_IN_TTL_KEY);
-}
-
-/**
- * Reads the stored sign-in metadata, normalising corrupt entries when necessary.
- *
- * @returns The stored timestamp/TTL pair, or `null` when not available.
- */
-export function getStoredSignInInfo(): StoredSignInInfo | null {
-	if (typeof window === 'undefined') {
-		return null;
-	}
-	const storage = window.localStorage;
-	const signedInAtStr = storage.getItem(SIGN_IN_AT_KEY);
-	if (!signedInAtStr) {
-		return null;
-	}
-
-	const signedInAt = Number.parseInt(signedInAtStr, 10);
-	if (!Number.isFinite(signedInAt)) {
-		clearSignInTracking();
-		return null;
-	}
-
-	const ttlStr = storage.getItem(SIGN_IN_TTL_KEY);
-	const ttlMs = ttlStr ? Number.parseInt(ttlStr, 10) : DEFAULT_AUTO_SIGN_OUT_MS;
-
-	return {
-		signedInAt,
-		ttlMs: Number.isFinite(ttlMs) ? ttlMs : DEFAULT_AUTO_SIGN_OUT_MS,
-	};
-}
-
-/**
- * Determines whether the stored session has exceeded its allowed TTL.
- *
- * @param durationOverrideMs - Optional override that supersedes the stored TTL.
- * @returns `true` if the session has expired, otherwise `false`.
- */
-export function isStoredSessionExpired(durationOverrideMs?: number) {
-	const info = getStoredSignInInfo();
-	if (!info) {
-		return false;
-	}
-
-	const ttlMs = durationOverrideMs ?? info.ttlMs ?? DEFAULT_AUTO_SIGN_OUT_MS;
-	const expiresAt = info.signedInAt + ttlMs;
-	return Date.now() >= expiresAt;
-}
 
 export function startAuthListener() {
 	// Events are emitted across tabs to keep application's UI up-to-date
@@ -102,47 +16,19 @@ export function startAuthListener() {
 		// Once we click on Sign Out button, event will be changed to SIGNED_OUT
 		if (event === 'SIGNED_OUT' || !session?.user) {
 			// is logged out
-			clearSignInTracking();
 			resetUser();
+			return;
 		}
 
-		if (session?.user && !currentUser) {
-			const u = session.user;
-			setUser({
-				id: u.id,
-				email: u.email ?? '',
-				display_name: u.user_metadata?.name ?? null,
-				photo_url: u.user_metadata?.avatar_url ?? null,
-			});
-		}
+		const u = session.user;
+		setUser({
+			id: u.id,
+			email: u.email ?? '',
+			display_name: u.user_metadata?.name ?? null,
+			photo_url: u.user_metadata?.avatar_url ?? null
+		});
 	});
 	return () => sub.subscription.unsubscribe();
-}
-
-/**
- * Signs the current user out if the session is expired.
- *
- * @param options.durationOverrideMs - Optional override that supersedes the stored TTL.
- * @param options.isDisable - When `true`, skips the auto sign-out logic entirely.
- * @returns Resolves to `true` when a sign-out occurred, otherwise `false`.
- */
-export async function signOutIfExpired(options?: {
-	durationOverrideMs?: number;
-	isDisable?: boolean;
-}) {
-	if (typeof window === 'undefined') {
-		return false;
-	}
-	if (options?.isDisable) {
-		return false;
-	}
-
-	const { durationOverrideMs } = options ?? {};
-	if (!isStoredSessionExpired(durationOverrideMs)) {
-		return false;
-	}
-	await signOut();
-	return true;
 }
 
 /**
@@ -162,11 +48,8 @@ export async function signIn() {
 			queryParams: {
 				prompt: 'select_account'
 			}
-		},
+		}
 	});
-
-	const autoSignOutMs = DEFAULT_AUTO_SIGN_OUT_MS;
-	persistSignInTimestamp(autoSignOutMs);
 
 	sessionLoading.set(false);
 }
@@ -175,7 +58,6 @@ export async function signIn() {
  * Signs the user out and clears any stored sign-in metadata.
  */
 export async function signOut() {
-	clearSignInTracking();
 	sessionLoading.set(true);
 	await supabase.auth.signOut();
 	sessionLoading.set(false);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,7 +7,6 @@ import { listCategories } from '$lib/data/categories.fetcher';
 import { listAppSetting } from '$lib/data/appSetting.fetcher';
 import { getTaiwanMonthKey } from '$lib/utils/dates';
 import { LOAD_DEP_KEYS } from '$lib/utils/const';
-import { signOutIfExpired } from '$lib/supabase/auth';
 import Logger from '$lib/utils/logger';
 
 export const load: LayoutLoad = async ({ depends, url }) => {
@@ -23,10 +22,6 @@ export const load: LayoutLoad = async ({ depends, url }) => {
 	depends(LOAD_DEP_KEYS.appSettings);
 	depends(LOAD_DEP_KEYS.expenses);
 
-	await signOutIfExpired({
-		isDisable: true, // cancel the auto sign-out. It used to be auto sign-out every 8 hours.
-	});
-
 	// 1) 取登入使用者（在 ssr=false 下可安全呼叫）
 	const { data: u } = await supabase.auth.getUser();
 	const user = u?.user
@@ -34,7 +29,7 @@ export const load: LayoutLoad = async ({ depends, url }) => {
 				id: u.user.id,
 				email: u.user.email ?? '',
 				display_name: u.user.user_metadata?.name ?? null,
-				photo_url: u.user.user_metadata?.avatar_url ?? null,
+				photo_url: u.user.user_metadata?.avatar_url ?? null
 			}
 		: null;
 
@@ -57,6 +52,6 @@ export const load: LayoutLoad = async ({ depends, url }) => {
 		user,
 		categories,
 		allowedEmails,
-		depKeys: LOAD_DEP_KEYS, // 給子層寫入後好用 invalidate(depKeys.xxx)
+		depKeys: LOAD_DEP_KEYS // 給子層寫入後好用 invalidate(depKeys.xxx)
 	};
 };


### PR DESCRIPTION
 ## Summary

  Cleaned up the Supabase auth flow so the app relies on Supabase’s built-in browser session handling instead of maintaining a second, custom login-expiry system.

  ## Why

  Supabase JS already persists the session, refreshes tokens, and exposes the current authenticated user through `supabase.auth.getUser()` and auth state events. The app was also carrying an older local `sign-in-
  at` / TTL mechanism, but that path was disabled with `isDisable: true`, so it added code complexity without affecting behavior.

  Browser-side JWKS verification was also removed because it does not provide meaningful security for app login state. Any code running in the browser can be bypassed by the client. The correct place to verify the
  access token for protected backend work is the receiving backend/Cloud Function. The frontend should fetch the Supabase session and pass the access token; the backend should validate it before doing privileged work.

  ## Changes

  - Removed the disabled custom 8-hour sign-in TTL tracking from `src/lib/supabase/auth.ts`.
  - Removed the no-op `signOutIfExpired({ isDisable: true })` call from `src/routes/+layout.ts`.
  - Fixed `startAuthListener()` so Supabase auth events update the session store whenever a valid session user exists.
  - Removed browser-side JWKS verification from `src/lib/data/ai-receipt.fetcher.ts`.
  - Removed the now-unused `jose` dependency from `package.json` and `package-lock.json`.

  ## Result

  The login state now has a single source of truth: Supabase Auth. The frontend checks the current user with Supabase and listens for auth state changes, while backend authorization remains the responsibility of the backend endpoint receiving the access token.

  ## Verification

  - Ran Prettier check on touched files: passed.
  - Ran `npm run check`: still fails due to an existing unrelated `virtual:pwa-info` type declaration issue in `src/routes/+layout.svelte`, plus pre-existing Svelte warnings.